### PR TITLE
クライアント起動時に、Extentionが無効に設定されていても常に有効になってしまう問題の修正

### DIFF
--- a/src/main/java/onim/en/etl/extension/ExtensionManager.java
+++ b/src/main/java/onim/en/etl/extension/ExtensionManager.java
@@ -169,6 +169,8 @@ public class ExtensionManager {
 
         if (entry.getValue().isEnabled()) {
           ExtensionManager.enableExtension(entry.getValue());
+        } else {
+          ExtensionManager.disableExtension(entry.getValue());
         }
       } catch (Exception e) {
         continue;


### PR DESCRIPTION
loadModuleSettings()でのフィールドに値を適用する処理後、そのExtensionが無効(isEnable()がfalse)になっていたら無効化の処理をするようにしました。
既に対応済みだったり、意図してこうしているのであればごめんなさい。