### PR TITLE
プレイヤーの頭上のステータス表示に職業を追加

### DIFF
--- a/src/main/java/onim/en/etl/extension/normal/PlayerStatusView.java
+++ b/src/main/java/onim/en/etl/extension/normal/PlayerStatusView.java
@@ -160,8 +160,9 @@ public class PlayerStatusView extends TheLowExtension {
     int i = this.drawText(status.mcid, 0, 0, a, false);
     GlStateManager.translate(i + 1, 0, 0);
     GlStateManager.scale(0.75, 0.75, 0.75);
-    this.drawText(TheLowUtil.formatClanName(status.clanInfo), 0, 2, a, false);
-    this.drawText(TheLowUtil.formatJobName(status.jobName), 0,  2, a, false);
+    int j = this.drawText(TheLowUtil.formatClanName(status.clanInfo), 0, 2, a, false);
+    GlStateManager.translate(j + 1, 0, 0);
+    this.drawText(TheLowUtil.formatJobName("§b" + status.jobName), 0,  2, a, false);
     GlStateManager.popMatrix();
 
     // Reinc count and main level

--- a/src/main/java/onim/en/etl/extension/normal/PlayerStatusView.java
+++ b/src/main/java/onim/en/etl/extension/normal/PlayerStatusView.java
@@ -161,6 +161,7 @@ public class PlayerStatusView extends TheLowExtension {
     GlStateManager.translate(i + 1, 0, 0);
     GlStateManager.scale(0.75, 0.75, 0.75);
     this.drawText(TheLowUtil.formatClanName(status.clanInfo), 0, 2, a, false);
+    this.drawText(TheLowUtil.formatJobName(status.jobName), 0,  2, a, false);
     GlStateManager.popMatrix();
 
     // Reinc count and main level


### PR DESCRIPTION
自分のステータス欄にのみ職業が追記されていましたが、クラン名の右にも職業名を追加しました。

./PlayerStatusView.java 内の[`TheLowUtil.formatJobName()`](https://github.com/Oni-Men/ExtendTheLow/blob/1.8.9/src/main/java/onim/en/etl/util/TheLowUtil.java#L73-L76) は　#3 の TheLowUtil内で追加されていたみたいです。

白文字が続くのは見にくいなと思ってカラーコードを付けましたが必要なかったら消してください。

![52b7a6c9a2f6abca1f078b57f88acf47](https://user-images.githubusercontent.com/87461070/160308668-b8b5c15d-a14f-48ea-9094-875c4ceb77c9.png)
