### PR TITLE
1.8.9 に対応。

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 tasks.withType(JavaCompile) {
-	options.encoding = 'UTF-8'
+    options.encoding = 'UTF-8'
 }
 
 
@@ -29,20 +29,20 @@ plugins {
 }
 */
 
-version = "1.0.8"
-group= "onim.en.etl" // http://maven.apache.org/guides/mini/guide-naming-conventions.html
+version = "1.0.9"
+group = "onim.en.etl" // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = "ExtendTheLow"
 
 minecraft {
-    version = "1.8.8-11.15.0.1655"
+    version = "1.8.9-11.15.1.2318-1.8.9"
     runDir = "run"
-    
+
     // the mappings can be changed at any time, and must be in the following format.
     // snapshot_YYYYMMDD   snapshot are built nightly.
     // stable_#            stables are built at the discretion of the MCP team.
     // Use non-default mappings at your own risk. they may not allways work.
     // simply re-run your setup task after changing the mappings to update your workspace.
-    mappings = "snapshot_20151122"
+    mappings = "stable_20"
     // makeObfSourceJar = false // an Srg named sources jar is made by default. uncomment this to disable.
 }
 
@@ -51,7 +51,7 @@ dependencies {
     // or you may define them like so..
     //compile "some.group:artifact:version:classifier"
     //compile "some.group:artifact:version"
-      
+
     // real examples
     //compile 'com.mod-buildcraft:buildcraft:6.0.8:dev'  // adds buildcraft to the dev env
     //compile 'com.googlecode.efficient-java-matrix-library:ejml:0.24' // adds ejml to the dev env
@@ -70,8 +70,7 @@ dependencies {
 
 }
 
-processResources
-{
+processResources {
     // this will ensure that this task is redone when the versions change.
     inputs.property "version", project.version
     inputs.property "mcversion", project.minecraft.version
@@ -79,9 +78,9 @@ processResources
     // replace stuff in mcmod.info, nothing else
     from(sourceSets.main.resources.srcDirs) {
         include 'mcmod.info'
-                
+
         // replace version and mcversion
-        expand 'version':project.version, 'mcversion':project.minecraft.version
+        expand 'version': project.version, 'mcversion': project.minecraft.version
     }
         
     // copy everything else, thats not the mcmod.info
@@ -93,6 +92,6 @@ processResources
 jar {
     manifest {
         attributes FMLCorePlugin: 'onim.en.etl.core.CoreLoader'
-        attributes FMLCorePluginContainsFMLMod : 'true'
+        attributes FMLCorePluginContainsFMLMod: 'true'
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ plugins {
 }
 */
 
-version = "1.0.9"
+version = "1.0.8"
 group = "onim.en.etl" // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = "ExtendTheLow"
 

--- a/src/main/java/onim/en/etl/api/HandleAPI.java
+++ b/src/main/java/onim/en/etl/api/HandleAPI.java
@@ -52,9 +52,7 @@ public class HandleAPI {
     }
 
     // 一分ごとにデータを更新
-    ExtendTheLow.apiScheduler = TickTaskExecutor.scheduleTask(() -> {
-      requestDatas();
-    }, randomDelay, 20 * 60);
+    ExtendTheLow.apiScheduler = TickTaskExecutor.scheduleTask(HandleAPI::requestDatas, randomDelay, 20 * 60);
   }
 
   public static void requestDatas() {

--- a/src/main/java/onim/en/etl/extension/ExtensionManager.java
+++ b/src/main/java/onim/en/etl/extension/ExtensionManager.java
@@ -42,11 +42,9 @@ public class ExtensionManager {
       ClassPath.from(loader)
         .getTopLevelClassesRecursive(PACKAGE_NAME)
         .stream()
-        .map(info -> info.load())
+        .map(ClassPath.ClassInfo::load)
         .sorted((a, b) -> a.getSimpleName().compareTo(b.getSimpleName()))
-        .forEach(c -> {
-          register(c);
-        });
+        .forEach(ExtensionManager::register);
     } catch (IOException e) {
       e.printStackTrace();
     }

--- a/src/main/java/onim/en/etl/extension/photo/PhotoMode.java
+++ b/src/main/java/onim/en/etl/extension/photo/PhotoMode.java
@@ -76,7 +76,7 @@ public class PhotoMode extends TheLowExtension {
     GL11.glLineWidth(1f);
 
     WorldRenderer buf = Tessellator.getInstance().getWorldRenderer();
-    buf.func_181668_a(GL11.GL_LINES, DefaultVertexFormats.field_181705_e);
+    buf.begin(GL11.GL_LINES, DefaultVertexFormats.POSITION);
 
     renderFrame(width, height);
 
@@ -122,38 +122,38 @@ public class PhotoMode extends TheLowExtension {
   private void renderFrame(double w, double h) {
     WorldRenderer buf = Tessellator.getInstance().getWorldRenderer();
 
-    buf.func_181662_b(0, 0, 0).func_181675_d();
-    buf.func_181662_b(w, 0, 0).func_181675_d();
+    buf.pos(0, 0, 0).endVertex();
+    buf.pos(w, 0, 0).endVertex();
 
-    buf.func_181662_b(w, 0, 0).func_181675_d();
-    buf.func_181662_b(w, h, 0).func_181675_d();
+    buf.pos(w, 0, 0).endVertex();
+    buf.pos(w, h, 0).endVertex();
 
 
-    buf.func_181662_b(w, h, 0).func_181675_d();
-    buf.func_181662_b(0, h, 0).func_181675_d();
+    buf.pos(w, h, 0).endVertex();
+    buf.pos(0, h, 0).endVertex();
 
-    buf.func_181662_b(0, h, 0).func_181675_d();
-    buf.func_181662_b(0, 0, 0).func_181675_d();
+    buf.pos(0, h, 0).endVertex();
+    buf.pos(0, 0, 0).endVertex();
   }
 
   private void renderDivideLines(double w, double h, int sect) {
     WorldRenderer buf = Tessellator.getInstance().getWorldRenderer();
     for (int i = 1; i < sect; i++) {
-      buf.func_181662_b(w / sect * i, 0, 0).func_181675_d();
-      buf.func_181662_b(w / sect * i, h, 0).func_181675_d();
+      buf.pos(w / sect * i, 0, 0).endVertex();
+      buf.pos(w / sect * i, h, 0).endVertex();
 
-      buf.func_181662_b(0, h / sect * i, 0).func_181675_d();
-      buf.func_181662_b(w, h / sect * i, 0).func_181675_d();
+      buf.pos(0, h / sect * i, 0).endVertex();
+      buf.pos(w, h / sect * i, 0).endVertex();
     }
   }
 
   private void renderDiagonal(double w, double h) {
     WorldRenderer buf = Tessellator.getInstance().getWorldRenderer();
-    buf.func_181662_b(0, 0, 0).func_181675_d();
-    buf.func_181662_b(w, h, 0).func_181675_d();
+    buf.pos(0, 0, 0).endVertex();
+    buf.pos(w, h, 0).endVertex();
 
-    buf.func_181662_b(w, 0, 0).func_181675_d();
-    buf.func_181662_b(0, h, 0).func_181675_d();
+    buf.pos(w, 0, 0).endVertex();
+    buf.pos(0, h, 0).endVertex();
   }
 
 }

--- a/src/main/java/onim/en/etl/ui/AdvancedFontRenderer.java
+++ b/src/main/java/onim/en/etl/ui/AdvancedFontRenderer.java
@@ -4,6 +4,7 @@ import java.awt.Font;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.lwjgl.opengl.GL11;
@@ -134,11 +135,10 @@ public class AdvancedFontRenderer extends FontRenderer implements IResourceManag
 
     switch (ch) {
       case 160:
+      case ' ':
         return 4F;
       case 167:
         return -1F;
-      case ' ':
-        return 4F;
     }
 
     float k = italic ? 1.2F : 0.0F;
@@ -187,11 +187,10 @@ public class AdvancedFontRenderer extends FontRenderer implements IResourceManag
   public float getCharWidthFloat(char ch) {
     switch (ch) {
       case 160:
+      case ' ':
         return 4F;
       case 167:
         return -1F;
-      case ' ':
-        return 4F;
     }
 
     int scaleFactor = new ScaledResolution(Minecraft.getMinecraft()).getScaleFactor();
@@ -257,7 +256,7 @@ public class AdvancedFontRenderer extends FontRenderer implements IResourceManag
   }
 
   private List<Font> deriveFonts(float scale, int style) {
-    return fonts.stream().filter(f -> f != null).map(f -> {
+    return fonts.stream().filter(Objects::nonNull).map(f -> {
       if (f.getFamily().equals("Ubuntu") && style == Font.BOLD) {
         return UbuntuBold.deriveFont(scale);
       }

--- a/src/main/java/onim/en/etl/ui/components/EnumSwitchButton.java
+++ b/src/main/java/onim/en/etl/ui/components/EnumSwitchButton.java
@@ -18,7 +18,7 @@ public class EnumSwitchButton<T extends Enum<T>> extends Button {
   public EnumSwitchButton(int widthIn, String initialValue, Class<T> enumType) {
     super(widthIn, "");
     this.enumType = enumType;
-    this.textList = Stream.of(enumType.getEnumConstants()).map(e -> e.name()).collect(Collectors.toList());
+    this.textList = Stream.of(enumType.getEnumConstants()).map(Enum::name).collect(Collectors.toList());
     if (initialValue != null) {
       this.enumValue = initialValue;
     } else if (!this.textList.isEmpty()) {

--- a/src/main/java/onim/en/etl/ui/custom/GuiSearchChest.java
+++ b/src/main/java/onim/en/etl/ui/custom/GuiSearchChest.java
@@ -79,19 +79,19 @@ public class GuiSearchChest extends GuiChest {
       GlStateManager.disableLighting();
       GL11.glLineWidth(4f);
       WorldRenderer buf = Tessellator.getInstance().getWorldRenderer();
-      buf.func_181668_a(GL11.GL_LINES, DefaultVertexFormats.field_181705_e);
+      buf.begin(GL11.GL_LINES, DefaultVertexFormats.POSITION);
 
-      buf.func_181662_b(-0.5, 0, 0).func_181675_d();
-      buf.func_181662_b(16.5, 0, 0).func_181675_d();
+      buf.pos(-0.5, 0, 0).endVertex();
+      buf.pos(16.5, 0, 0).endVertex();
 
-      buf.func_181662_b(16, 0, 0).func_181675_d();
-      buf.func_181662_b(16, 16, 0).func_181675_d();
+      buf.pos(16, 0, 0).endVertex();
+      buf.pos(16, 16, 0).endVertex();
 
-      buf.func_181662_b(16.5, 16, 0).func_181675_d();
-      buf.func_181662_b(-0.5, 16, 0).func_181675_d();
+      buf.pos(16.5, 16, 0).endVertex();
+      buf.pos(-0.5, 16, 0).endVertex();
 
-      buf.func_181662_b(0, 16, 0).func_181675_d();
-      buf.func_181662_b(0, 0, 0).func_181675_d();
+      buf.pos(0, 16, 0).endVertex();
+      buf.pos(0, 0, 0).endVertex();
 
       Tessellator.getInstance().draw();
 

--- a/src/main/java/onim/en/etl/ui/custom/QuickActionSetting.java
+++ b/src/main/java/onim/en/etl/ui/custom/QuickActionSetting.java
@@ -22,9 +22,7 @@ public class QuickActionSetting extends GuiExtendTheLow {
     super("onim.en.etl.quickAction");
     this.setInitializer(list -> {
       Button button = new Button(100, "Reset");
-      button.setOnAction(() -> {
-        QuickActionManager.reset();
-      });
+      button.setOnAction(QuickActionManager::reset);
       list.add(button);
     });
   }

--- a/src/main/java/onim/en/etl/util/FontUtil.java
+++ b/src/main/java/onim/en/etl/util/FontUtil.java
@@ -59,7 +59,7 @@ public class FontUtil {
     // String[] availableFontFamilyNames = localGfxEnv.getAvailableFontFamilyNames();
     // return Arrays.asList(availableFontFamilyNames);
     return Stream.of(localGfxEnv.getAllFonts()).map(
-        f -> f.getFamily()).distinct().collect(
+        Font::getFamily).distinct().collect(
         Collectors.toList());
   }
 

--- a/src/main/java/onim/en/etl/util/GuiUtil.java
+++ b/src/main/java/onim/en/etl/util/GuiUtil.java
@@ -282,15 +282,15 @@ public class GuiUtil {
     GlStateManager.shadeModel(7425);
     Tessellator tessellator = Tessellator.getInstance();
     WorldRenderer worldrenderer = tessellator.getWorldRenderer();
-    worldrenderer.func_181668_a(7, DefaultVertexFormats.field_181706_f);
-    worldrenderer.func_181662_b((double) right, (double) top, (double) 0).func_181666_a(red2, green2, blue2, alpha2)
-      .func_181675_d();
-    worldrenderer.func_181662_b((double) left, (double) top, (double) 0).func_181666_a(red1, green1, blue1, alpha1)
-      .func_181675_d();
-    worldrenderer.func_181662_b((double) left, (double) bottom, (double) 0).func_181666_a(red1, green1, blue1, alpha1)
-      .func_181675_d();
-    worldrenderer.func_181662_b((double) right, (double) bottom, (double) 0).func_181666_a(red2, green2, blue2, alpha2)
-      .func_181675_d();
+    worldrenderer.begin(7, DefaultVertexFormats.POSITION_COLOR);
+    worldrenderer.pos((double) right, (double) top, (double) 0).color(red2, green2, blue2, alpha2)
+      .endVertex();
+    worldrenderer.pos((double) left, (double) top, (double) 0).color(red1, green1, blue1, alpha1)
+      .endVertex();
+    worldrenderer.pos((double) left, (double) bottom, (double) 0).color(red1, green1, blue1, alpha1)
+      .endVertex();
+    worldrenderer.pos((double) right, (double) bottom, (double) 0).color(red2, green2, blue2, alpha2)
+      .endVertex();
     tessellator.draw();
     GlStateManager.shadeModel(7424);
     GlStateManager.disableBlend();

--- a/src/main/java/onim/en/etl/util/GuiUtil.java
+++ b/src/main/java/onim/en/etl/util/GuiUtil.java
@@ -57,13 +57,11 @@ public class GuiUtil {
 
   public static void openCategorySettingGUI(String category, GuiScreen prevScreen) {
     GuiExtendTheLow gui = new GuiExtendTheLow(category, prevScreen);
-    gui.setInitializer(buttonList -> {
-      ExtensionManager.getCategoryExtensions(category).forEach(extension -> {
-        Button button = new Button(100, extension.id());
-        button.setOnAction(() -> openExtensionSettingGUI(extension, gui));
-        buttonList.add(button);
-      });
-    });
+    gui.setInitializer(buttonList -> ExtensionManager.getCategoryExtensions(category).forEach(extension -> {
+      Button button = new Button(100, extension.id());
+      button.setOnAction(() -> openExtensionSettingGUI(extension, gui));
+      buttonList.add(button);
+    }));
 
     Minecraft.getMinecraft().displayGuiScreen(gui);
   }
@@ -85,7 +83,7 @@ public class GuiUtil {
         }
       });
     });
-    gui.setOnClose(() -> ExtensionManager.saveModuleSettings());
+    gui.setOnClose(ExtensionManager::saveModuleSettings);
     Minecraft.getMinecraft().displayGuiScreen(gui);
   }
 
@@ -182,12 +180,10 @@ public class GuiUtil {
 
   public static Button getResetSettingsButton() {
     Button button = new Button(100, "onim.en.etl.resetSettings");
-    button.setOnAction(() -> {
-      openConfirmGUI("onim.en.etl.confirmResetSettings", () -> {
-        Prefs.reset();
-        ExtensionManager.resetModuleSettings();
-      });
-    });
+    button.setOnAction(() -> openConfirmGUI("onim.en.etl.confirmResetSettings", () -> {
+      Prefs.reset();
+      ExtensionManager.resetModuleSettings();
+    }));
     return button;
   }
 
@@ -201,9 +197,7 @@ public class GuiUtil {
         Minecraft.getMinecraft().displayGuiScreen(null);
       });
       
-      noButton.setOnAction(() -> {
-        Minecraft.getMinecraft().displayGuiScreen(null);
-      });
+      noButton.setOnAction(() -> Minecraft.getMinecraft().displayGuiScreen(null));
 
       buttonList.add(noButton);
       buttonList.add(yesButton);
@@ -215,24 +209,16 @@ public class GuiUtil {
   public static void openGeneralSettingsGUI(GuiScreen prevScreen) {
     GuiExtendTheLow gui = new GuiExtendTheLow("onim.en.etl.generalSettings", prevScreen);
     gui.setInitializer(buttonList -> {
-      buttonList.add(new ToggleButton("onim.en.etl.advancedFont", Prefs.get().betterFont, b -> {
-        Prefs.get().betterFont = b;
-      }));
+      buttonList.add(new ToggleButton("onim.en.etl.advancedFont", Prefs.get().betterFont, b -> Prefs.get().betterFont = b));
       buttonList
-        .add(new ToggleButton("onim.en.etl.customStatus", Prefs.get().customTheLowStatus, b -> {
-          Prefs.get().customTheLowStatus = b;
-        }));
-      buttonList.add(new ToggleButton("onim.en.etl.invertCustomStatus", Prefs.get().invertTheLowStatus, b -> {
-        Prefs.get().invertTheLowStatus = b;
-      }));
-      buttonList.add(new ToggleButton("onim.en.etl.smartHealthBar", Prefs.get().smartHealthBar, b -> {
-        Prefs.get().smartHealthBar = b;
-      }));
+        .add(new ToggleButton("onim.en.etl.customStatus", Prefs.get().customTheLowStatus, b -> Prefs.get().customTheLowStatus = b));
+      buttonList.add(new ToggleButton("onim.en.etl.invertCustomStatus", Prefs.get().invertTheLowStatus, b -> Prefs.get().invertTheLowStatus = b));
+      buttonList.add(new ToggleButton("onim.en.etl.smartHealthBar", Prefs.get().smartHealthBar, b -> Prefs.get().smartHealthBar = b));
       buttonList.add(getClearCacheButton());
       buttonList.add(getResetSettingsButton());
     });
 
-    gui.setOnClose(() -> Prefs.save());
+    gui.setOnClose(Prefs::save);
 
     Minecraft.getMinecraft().displayGuiScreen(gui);
   }

--- a/src/main/java/onim/en/etl/util/TickTaskExecutor.java
+++ b/src/main/java/onim/en/etl/util/TickTaskExecutor.java
@@ -34,9 +34,7 @@ public class TickTaskExecutor {
 
   public static void advanceScheduledTasks() {
     scheduledTasks.entrySet().removeIf(e -> e.getValue().isCanceled());
-    scheduledTasks.values().forEach(task -> {
-      task.tick();
-    });
+    scheduledTasks.values().forEach(TickTask::tick);
 
     TickTask task = null;
     while (syncTaskPool.size() > 0) {


### PR DESCRIPTION
- gradleファイルの変更(forge-1.8.9に対応)
- `WorldRenderer`クラスのメソッドを1.8.9に対応 (1.8.9で一部のメソッド・フィールド名が変わった[参考：](https://github.com/Deadrik/TFC2/tree/master/custommappings))
- ラムダ式に置換できそうだったので。
- 最後、1.0.9に変更ミスしていたのを修正。


最近更新されていないようなのでほぼ意味ないですが。。。